### PR TITLE
Assume that rules with output interfaces not part of the routing table never match

### DIFF
--- a/haskell_tool/lib/Network/IPTables/Generated.hs
+++ b/haskell_tool/lib/Network/IPTables/Generated.hs
@@ -3662,7 +3662,7 @@ ipassmt_iface_replace_dstip_mexpr ::
                  Iface -> Match_expr (Common_primitive a);
 ipassmt_iface_replace_dstip_mexpr ipassmt ifce =
   (case ipassmt ifce of {
-    Nothing -> Match (OIface ifce);
+    Nothing -> MatchNot MatchAny;
     Just ips ->
       match_list_to_match_expr
         (map (Match . Dst) (map (uncurry IpAddrNetmask) ips));


### PR DESCRIPTION
This has an effect if a routing table was specified only. The current implementation keeps the interfaces if they are not part of the routing table. Due to the over approximation, this assumes that traffic is allowed while it is not.

This modifieds the generated code which is a bad practice. However, I could not make isabelle generate code at all.